### PR TITLE
Define names for ip address sets centrally

### DIFF
--- a/cc-to-ipset-script.sh
+++ b/cc-to-ipset-script.sh
@@ -68,6 +68,8 @@ OWD="$(pwd)"
 cd "$(mktemp -d)" || exit
 
 while read -r CC; do
+  addressSet4="$CC-4"
+  addressSet6="$CC-6"
   echo "Building $CC list in $(pwd)"
   # Download the CC list.
   wget -qO "$CC-$today.txt" "https://www.ipdeny.com/ipblocks/data/countries/$CC.zone"
@@ -75,26 +77,26 @@ while read -r CC; do
     # Destroy ipsets.
     # Note: This does not work for existing ipsets in use. You would need to make
     # different ipsets and swap them in.
-    #echo "ipset -X $CC-4" > "$CC-ipset-$today.sh"
-    #echo "ipset -X $CC-6" >> "$CC-ipset-$today.sh"
+    #echo "ipset -X $addressSet4" > "$CC-ipset-$today.sh"
+    #echo "ipset -X $addressSet6" >> "$CC-ipset-$today.sh"
     # Create ipsets to block a CIDR range.
-    echo "ipset -N $CC-4 hash:net family inet"
-    echo "ipset -N $CC-6 hash:net family inet6"
+    echo "ipset -N $addressSet4 hash:net family inet"
+    echo "ipset -N $addressSet6 hash:net family inet6"
     # Add CIDR to ipset.
     grep -v ":" "$CC-$today.txt" \
-      | sed "s/^/ipset -A $CC-4 /g"
+      | sed "s/^/ipset -A $addressSet4 /g"
     grep ":" "$CC-$today.txt" \
-      | sed "s/^/ipset -A $CC-6 /g"
+      | sed "s/^/ipset -A $addressSet6 /g"
     # Adds the ipset to iptables for all ports.
-    echo "iptables -I INPUT 1 -m set --match-set $CC-4 src -j DROP"
-    echo "iptables -I FORWARD 1 -m set --match-set $CC-4 src -j DROP"
-    echo "ip6tables -I INPUT 1 -m set --match-set $CC-6 src -j DROP"
-    echo "ip6tables -I FORWARD 1 -m set --match-set $CC-6 src -j DROP"
+    echo "iptables -I INPUT 1 -m set --match-set $addressSet4 src -j DROP"
+    echo "iptables -I FORWARD 1 -m set --match-set $addressSet4 src -j DROP"
+    echo "ip6tables -I INPUT 1 -m set --match-set $addressSet6 src -j DROP"
+    echo "ip6tables -I FORWARD 1 -m set --match-set $addressSet6 src -j DROP"
     # Adds the ipset to iptables for only ports 80 and 443 for tcp connections.
-    # echo "iptables -I INPUT 1 -p tcp -m multiport --dports 80,443 -m set --match-set $CC-4 src -j DROP"
-    # echo "iptables -I FORWARD 1 -p tcp -m multiport --dports 80,443 -m set --match-set $CC-4 src -j DROP"
-    # echo "ip6tables -I INPUT 1 -p tcp -m multiport --dports 80,443 -m set --match-set $CC-6 src -j DROP"
-    # echo "ip6tables -I FORWARD 1 -p tcp -m multiport --dports 80,443 -m set --match-set $CC-6 src -j DROP"
+    # echo "iptables -I INPUT 1 -p tcp -m multiport --dports 80,443 -m set --match-set $addressSet4 src -j DROP"
+    # echo "iptables -I FORWARD 1 -p tcp -m multiport --dports 80,443 -m set --match-set $addressSet4 src -j DROP"
+    # echo "ip6tables -I INPUT 1 -p tcp -m multiport --dports 80,443 -m set --match-set $addressSet6 src -j DROP"
+    # echo "ip6tables -I FORWARD 1 -p tcp -m multiport --dports 80,443 -m set --match-set $addressSet6 src -j DROP"
   } >> "$CC-ipset-$today.sh"
   # Copy the file to the ipset directory.
   mkdir -p "$OWD/ipset"


### PR DESCRIPTION
- to prevent possible future divergence (updating a name somewhere, not elsewhere)

- to "document" what the strings represent so their link/connection is more visible in the script